### PR TITLE
fix: correct pytest configuration to eliminate test warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 asyncio_mode = auto
 testpaths = tests
 python_files = test_*.py


### PR DESCRIPTION
## Summary
• Fixed pytest.ini configuration format to properly register custom markers
• Eliminates 20 pytest warnings about unknown markers
• Maintains full test functionality with cleaner output

## Changes Made
• Changed `[tool:pytest]` to `[pytest]` in pytest.ini
• This properly registers custom markers: `unit`, `integration`, `auth`, `slow`
• No functional changes to test behavior

## Test Results
**Before**: 124 tests passed, 20 warnings
**After**: 124 tests passed, 0 warnings

## Test Plan
- [x] All 124 tests continue to pass
- [x] Zero pytest warnings about unknown markers
- [x] Custom markers properly recognized by pytest
- [x] Test execution behavior unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)