### PR TITLE
Rebrand CyberArk to Idira in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# CyberArk Privilege Cloud MCP Server
+# Idira Privilege Cloud MCP Server
 
-An MCP server for CyberArk Privilege Cloud, built on the official [ark-sdk-python](https://github.com/cyberark/ark-sdk-python) library. Provides 53 tools for privileged access management.
+An MCP server for Idira (formerly CyberArk) Privilege Cloud, built on the official [ark-sdk-python](https://github.com/cyberark/ark-sdk-python) library. Provides 53 tools for privileged access management.
 
 Supports two authentication modes:
-- **OAuth per-user mode** (recommended) -- each user authenticates with their own CyberArk Identity credentials via OAuth. Requires [Streamable HTTP transport](#docker-deployment) and an OIDC app in CyberArk Identity ([setup guide](docs/CYBERARK_IDENTITY_SETUP.md)).
+- **OAuth per-user mode** (recommended) -- each user authenticates with their own Idira Identity credentials via OAuth. Requires [Streamable HTTP transport](#docker-deployment) and an OIDC app in Idira Identity ([setup guide](docs/CYBERARK_IDENTITY_SETUP.md)).
 - **Legacy service account mode** -- a single shared service account authenticates all requests via stdio transport. Simpler setup, shown in [Quick Start](#quick-start) below.
 
 ## Quick Start
@@ -66,22 +66,22 @@ Once configured, you can ask Claude things like:
 
 ## Prerequisites
 
-- [CyberArk Identity Service User](https://docs.cyberark.com/identity-administration/latest/en/content/ispss/ispss-add-service-user.htm) with:
+- [Idira Identity Service User](https://docs.cyberark.com/identity-administration/latest/en/content/ispss/ispss-add-service-user.htm) with:
   - Appropriate Identity roles for the desired operations (e.g., Privilege Cloud Administrator for platform management)
   - Safe permissions granting access to the safes and accounts you want to manage
-- For OAuth per-user mode: an OIDC app in CyberArk Identity (see [setup guide](docs/CYBERARK_IDENTITY_SETUP.md))
+- For OAuth per-user mode: an OIDC app in Idira Identity (see [setup guide](docs/CYBERARK_IDENTITY_SETUP.md))
 
 ## Configuration
 
 ### OAuth Per-User Mode
 
-Each connecting user authenticates with their own CyberArk Identity credentials via OAuth. The server verifies user identity from the OIDC JWT, then uses a shared service account platform token for all PCloud API calls.
+Each connecting user authenticates with their own Idira Identity credentials via OAuth. The server verifies user identity from the OIDC JWT, then uses a shared service account platform token for all PCloud API calls.
 
 Requires Streamable HTTP transport -- see [Docker Deployment](#docker-deployment) or set `MCP_TRANSPORT=streamable-http` when running locally.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `CYBERARK_IDENTITY_TENANT_URL` | Yes | CyberArk Identity tenant URL (e.g., `https://abc1234.id.cyberark.cloud`) |
+| `CYBERARK_IDENTITY_TENANT_URL` | Yes | Idira Identity tenant URL (e.g., `https://abc1234.id.cyberark.cloud`) |
 | `CYBERARK_CLIENT_ID` | Yes | Service account login name (for PCloud platform token) |
 | `CYBERARK_CLIENT_SECRET` | Yes | Service account password |
 | `CYBERARK_OAUTH_CLIENT_ID` | Yes | OIDC app client ID from Trust tab (for DCR and JWT audience) |
@@ -91,7 +91,7 @@ Requires Streamable HTTP transport -- see [Docker Deployment](#docker-deployment
 | `MCP_PORT` | No | Server bind port (default: `8000`) |
 | `MCP_SERVER_URL` | No | Public URL for OAuth metadata (default: `http://{host}:{port}`) |
 
-See [CyberArk Identity Setup](docs/CYBERARK_IDENTITY_SETUP.md) for full configuration instructions.
+See [Idira Identity Setup](docs/CYBERARK_IDENTITY_SETUP.md) for full configuration instructions.
 
 ### Legacy Service Account Mode
 
@@ -141,7 +141,7 @@ When deploying behind a reverse proxy, configure it to strip trailing slashes fr
 | Issue | Solution |
 |-------|----------|
 | MCP not appearing in Claude | Restart Claude Desktop after saving configuration |
-| Authentication failed | Verify Service User credentials in CyberArk Identity |
+| Authentication failed | Verify Service User credentials in Idira Identity |
 | Permission errors | Ensure the Service User has appropriate Identity roles and safe permissions |
 | Connection issues | Verify you're using the `.cloud` domain (not `.com`) |
 | OAuth 401 behind reverse proxy | Ensure the proxy strips trailing slashes (see [Docker Deployment](#docker-deployment)) |
@@ -167,7 +167,7 @@ uv run mcp-privilege-cloud                 # Run the server locally
 
 - **[API Reference](docs/API_REFERENCE.md)** - Complete tool specifications and parameters
 - **[Architecture](docs/ARCHITECTURE.md)** - System design and components
-- **[CyberArk Identity Setup](docs/CYBERARK_IDENTITY_SETUP.md)** - OAuth app configuration guide
+- **[Idira Identity Setup](docs/CYBERARK_IDENTITY_SETUP.md)** - OAuth app configuration guide
 - **[Development Guide](docs/DEVELOPMENT.md)** - Contributing and development workflows
 - **[Testing Guide](docs/TESTING.md)** - Detailed testing instructions
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Comprehensive API reference for the CyberArk Privilege Cloud MCP Server. This guide provides complete specifications, parameters, examples, and integration details for all available MCP tools.
+Comprehensive API reference for the Idira Privilege Cloud MCP Server. This guide provides complete specifications, parameters, examples, and integration details for all available MCP tools.
 
 ## Table of Contents
 
@@ -19,7 +19,7 @@ Comprehensive API reference for the CyberArk Privilege Cloud MCP Server. This gu
 
 ## Overview
 
-The CyberArk Privilege Cloud MCP Server provides **53 enterprise-grade tools** for comprehensive privileged account management through the Model Context Protocol (MCP). All tools follow consistent patterns built on the official ark-sdk-python library for authentication, parameter validation, and error handling.
+The Idira Privilege Cloud MCP Server provides **53 enterprise-grade tools** for comprehensive privileged account management through the Model Context Protocol (MCP). All tools follow consistent patterns built on the official ark-sdk-python library for authentication, parameter validation, and error handling.
 
 ### Core Capabilities
 - **Complete Account Lifecycle**: Create, read, update, delete accounts with advanced search and password management (18 tools)
@@ -43,7 +43,7 @@ The server supports two authentication modes, auto-detected from environment var
 
 ### OAuth Per-User Mode (Recommended)
 
-Each user authenticates with their own CyberArk Identity credentials via OAuth. The server verifies user identity from the OIDC JWT, then uses a shared service account platform token for all PCloud API calls.
+Each user authenticates with their own Idira Identity credentials via OAuth. The server verifies user identity from the OIDC JWT, then uses a shared service account platform token for all PCloud API calls.
 
 ```bash
 # Required for OAuth per-user mode
@@ -81,7 +81,7 @@ CYBERARK_CLIENT_SECRET=service-account-password
 
 ## Tool Categories
 
-The server provides 53 enterprise-grade tools organized across all 5 CyberArk PCloud services:
+The server provides 53 enterprise-grade tools organized across all 5 Idira PCloud services:
 
 ### Account Management Tools (18 tools)
 **Core Operations**: `list_accounts`, `get_account_details`, `search_accounts`, `create_account`, `update_account`, `delete_account`
@@ -112,7 +112,7 @@ The server provides 53 enterprise-grade tools organized across all 5 CyberArk PC
 
 ### `list_accounts`
 
-**Description**: List all accessible accounts in CyberArk Privilege Cloud.
+**Description**: List all accessible accounts in Idira Privilege Cloud.
 
 **Parameters**: None
 
@@ -217,7 +217,7 @@ await client.call_tool("get_account_details", {
 
 ### `create_account`
 
-**Description**: Create a new privileged account in CyberArk Privilege Cloud.
+**Description**: Create a new privileged account in Idira Privilege Cloud.
 
 **API Endpoint**: `POST /PasswordVault/API/Accounts`
 
@@ -298,7 +298,7 @@ await client.call_tool("create_account", {
 
 ### `list_safes`
 
-**Description**: List all accessible safes in CyberArk Privilege Cloud.
+**Description**: List all accessible safes in Idira Privilege Cloud.
 
 **Parameters**: None
 
@@ -396,7 +396,7 @@ await client.call_tool("get_safe_details", {
 
 ### `list_platforms`
 
-**Description**: List all available platforms in CyberArk Privilege Cloud.
+**Description**: List all available platforms in Idira Privilege Cloud.
 
 **Required Permissions**: Service account must be a member of the Privilege Cloud Administrator role
 
@@ -436,7 +436,7 @@ platforms = await client.call_tool("list_platforms", {})
 
 ### `import_platform_package`
 
-**Description**: Import a platform package into CyberArk Privilege Cloud.
+**Description**: Import a platform package into Idira Privilege Cloud.
 
 **API Endpoint**: `POST /PasswordVault/API/Platforms/Import`
 
@@ -471,7 +471,7 @@ await client.call_tool("import_platform_package", {
 ### Core Operations (4 tools)
 
 #### `list_applications`
-**Description**: List all applications in CyberArk Privilege Cloud  
+**Description**: List all applications in Idira Privilege Cloud  
 **Parameters**: Standard listing parameters (search, filter, sort, limit)  
 **Returns**: Array of application objects with basic properties  
 **SDK Method**: `ArkPCloudApplicationsService.list_applications()`
@@ -483,7 +483,7 @@ await client.call_tool("import_platform_package", {
 **SDK Method**: `ArkPCloudApplicationsService.get_application()`
 
 #### `add_application`
-**Description**: Create a new application in CyberArk Privilege Cloud  
+**Description**: Create a new application in Idira Privilege Cloud  
 **Parameters**: Application configuration (name, description, location, access_permissions, etc.)  
 **Returns**: Created application object with generated ID  
 **SDK Method**: `ArkPCloudApplicationsService.add_application()`
@@ -681,7 +681,7 @@ await client.call_tool("reconcile_account_password", {
 ### Core Operations (4 tools)
 
 #### `list_sessions`
-**Description**: List all privileged sessions in CyberArk Privilege Cloud
+**Description**: List all privileged sessions in Idira Privilege Cloud
 **Parameters**: Standard listing parameters
 **Returns**: Array of session objects with basic properties
 **SDK Method**: `ArkSMService.list_sessions()`
@@ -972,7 +972,7 @@ async def robust_account_creation(account_data):
 - Pagination for large datasets
 
 ### Rate Limiting
-- Respects CyberArk API rate limits
+- Respects Idira API rate limits
 - Automatic retry with exponential backoff
 - Connection management optimization
 
@@ -987,4 +987,4 @@ async def robust_account_creation(account_data):
 
 ---
 
-This API reference provides comprehensive documentation for integrating with the CyberArk Privilege Cloud MCP Server. For additional examples and testing guidance, refer to the [Testing Guide](TESTING.md).
+This API reference provides comprehensive documentation for integrating with the Idira Privilege Cloud MCP Server. For additional examples and testing guidance, refer to the [Testing Guide](TESTING.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# CyberArk Privilege Cloud MCP Server - Architecture Reference
+# Idira Privilege Cloud MCP Server - Architecture Reference
 
 **🤖 LLM REFERENCE**: This document provides complete architectural patterns for implementing new features. Use as reference for maintaining consistency with established patterns.
 
@@ -8,7 +8,7 @@
 
 ## Overview
 
-The CyberArk Privilege Cloud MCP Server follows a **simplified, streamlined architecture** leveraging the official CyberArk SDK, with clear separation of concerns and enterprise-grade reliability. Through comprehensive refactoring, the codebase achieved **~27% code reduction** while maintaining full functionality. It enables AI assistants to securely manage privileged accounts through the Model Context Protocol (MCP) with official CyberArk support.
+The Idira Privilege Cloud MCP Server follows a **simplified, streamlined architecture** leveraging the official Idira SDK, with clear separation of concerns and enterprise-grade reliability. Through comprehensive refactoring, the codebase achieved **~27% code reduction** while maintaining full functionality. It enables AI assistants to securely manage privileged accounts through the Model Context Protocol (MCP) with official Idira support.
 
 ## Core Components
 
@@ -17,8 +17,8 @@ The project is structured around these core modules leveraging the official ark-
 ```
 src/mcp_privilege_cloud/
 ├── sdk_auth.py          # Legacy service account authentication
-├── token_verifier.py    # JWT verification via CyberArk Identity JWKS
-├── server.py            # Core CyberArk API integration via SDK
+├── token_verifier.py    # JWT verification via Idira Identity JWKS
+├── server.py            # Core Idira API integration via SDK
 ├── mcp_server.py        # MCP protocol implementation (Streamable HTTP)
 └── exceptions.py        # Custom exception handling
 ```
@@ -28,7 +28,7 @@ src/mcp_privilege_cloud/
 The server supports two authentication modes:
 
 **OAuth Per-User Mode** (recommended for multi-user deployments):
-- Users authenticate via CyberArk Identity OAuth Authorization Code flow
+- Users authenticate via Idira Identity OAuth Authorization Code flow
 - Each user's JWT is verified against the JWKS endpoint by `CyberArkTokenVerifier`
 - A shared service account platform token is used for all PCloud API calls
 - User identity from the JWT is logged for audit purposes
@@ -40,10 +40,10 @@ The server supports two authentication modes:
 
 ### 1. Token Verifier (`token_verifier.py`)
 
-**Purpose**: MCP SDK `TokenVerifier` protocol implementation for CyberArk Identity JWTs
+**Purpose**: MCP SDK `TokenVerifier` protocol implementation for Idira Identity JWTs
 
 **Key Features**:
-- **JWKS Validation**: Verifies JWT signatures against CyberArk Identity `/oauth2/certs`
+- **JWKS Validation**: Verifies JWT signatures against Idira Identity `/oauth2/certs`
 - **MCP Protocol Compliance**: Returns `AccessToken` for MCP auth middleware
 - **Claim Validation**: Enforces `exp`, `iss`, `sub`, `aud` with RS256 algorithm
 - **Graceful Failures**: Returns `None` on any verification failure (no exceptions)
@@ -80,7 +80,7 @@ The server supports two authentication modes:
 
 **Key Features**:
 - **FastMCP Server**: MCP protocol implementation
-- **Comprehensive Tool Suite**: 53 enterprise-grade action tools for complete CyberArk PCloud operations across all 5 services (18+10+10+9+6)
+- **Comprehensive Tool Suite**: 53 enterprise-grade action tools for complete Idira PCloud operations across all 5 services (18+10+10+9+6)
 - **SDK-Powered Reliability**: All tools leverage official ark-sdk-python services
 - **Parameter Validation**: Enhanced input validation and type checking
 - **Cross-Platform Support**: Windows encoding compatibility
@@ -103,16 +103,16 @@ execute_tool() → get_access_token() → verify user identity (audit log)
                                               ↓
                               Shared CyberArkMCPServer (service account)
                                               ↓
-                              SDK Services → CyberArk PCloud API
+                              SDK Services → Idira PCloud API
 ```
 
 **Legacy Service Account Mode:**
 ```
-Client Request → MCP Tool → Server Method → SDK Auth → ark-sdk-python → CyberArk Identity
+Client Request → MCP Tool → Server Method → SDK Auth → ark-sdk-python → Idira Identity
                                       ↓                      ↓
                               SDK Service Instance    Auto Token Management
                                       ↓                      ↓
-Server Method → SDK Service → CyberArk API → SDK Response → MCP Response
+Server Method → SDK Service → Idira API → SDK Response → MCP Response
 ```
 
 ### Base URLs and Endpoints
@@ -154,14 +154,14 @@ Server Method → SDK Service → CyberArk API → SDK Response → MCP Response
 2. **MCP Server** validates parameters and routes to server method
 3. **Server Method** obtains SDK service instance (accounts/safes/platforms/applications for complete PCloud coverage)
 4. **SDK Service** automatically handles authentication via ark-sdk-python
-5. **SDK Service** calls CyberArk API with proper authentication and error handling
+5. **SDK Service** calls Idira API with proper authentication and error handling
 6. **SDK Response** provides exact API data with built-in data integrity
 7. **MCP Response** returns SDK response data to client with enhanced reliability
 
 ### Configuration Management
 
 **OAuth Per-User Mode Environment Variables** (recommended):
-- `CYBERARK_IDENTITY_TENANT_URL` - CyberArk Identity tenant URL (e.g., `https://abc1234.id.cyberark.cloud`)
+- `CYBERARK_IDENTITY_TENANT_URL` - Idira Identity tenant URL (e.g., `https://abc1234.id.cyberark.cloud`)
 - `CYBERARK_CLIENT_ID` - Service account login name (for PCloud platform token)
 - `CYBERARK_CLIENT_SECRET` - Service account password
 - `CYBERARK_OAUTH_CLIENT_ID` - OIDC app client ID from Trust tab (for DCR and JWT audience)

--- a/docs/CYBERARK_IDENTITY_SETUP.md
+++ b/docs/CYBERARK_IDENTITY_SETUP.md
@@ -1,15 +1,15 @@
-# CyberArk Identity Setup Guide
+# Idira Identity Setup Guide
 
-This guide explains how to configure CyberArk Identity for use with the MCP Privilege Cloud server in OAuth per-user mode.
+This guide explains how to configure Idira Identity for use with the MCP Privilege Cloud server in OAuth per-user mode.
 
 ## Prerequisites
 
-- CyberArk Identity administrator access
-- CyberArk Privilege Cloud tenant
+- Idira Identity administrator access
+- Idira Privilege Cloud tenant
 
 ## Part A: Create a Service User (OAuth Confidential Client)
 
-CyberArk Identity OAuth2 apps do NOT provide their own client_id/client_secret. Instead, credentials come from a **service user** marked as an OAuth 2.0 confidential client.
+Idira Identity OAuth2 apps do NOT provide their own client_id/client_secret. Instead, credentials come from a **service user** marked as an OAuth 2.0 confidential client.
 
 ### Step 1: Create the Service User
 
@@ -81,7 +81,7 @@ These are different from the service user credentials in Part A.
 | `openid` | Yes | Produces the `sub` claim (user identity) — the MCP server requires this claim and rejects tokens without it |
 | `profile` | Recommended | Adds `unique_name` and display name claims for richer audit logging |
 
-**Required JWT Claims**: The MCP server validates these claims on every request. All are standard OIDC claims produced automatically by CyberArk Identity when the scopes above are configured:
+**Required JWT Claims**: The MCP server validates these claims on every request. All are standard OIDC claims produced automatically by Idira Identity when the scopes above are configured:
 
 | Claim | Set By | Validated Against |
 |-------|--------|-------------------|
@@ -92,7 +92,7 @@ These are different from the service user credentials in Part A.
 
 ### Step 5: Add Trusted DNS Domains (Required for PKCE Clients)
 
-CyberArk Identity requires PKCE clients to have their domain added to trusted DNS domains:
+Idira Identity requires PKCE clients to have their domain added to trusted DNS domains:
 
 1. Navigate to **Settings** > **Authentication** > **Security Settings** > **API Security**
 2. Under **Trusted DNS Domains for API Calls**, add:
@@ -100,7 +100,7 @@ CyberArk Identity requires PKCE clients to have their domain added to trusted DN
    - Any other MCP client domains that will use the OAuth flow
 3. Save the settings
 
-**Without this step, CyberArk Identity will return `invalid_client` errors during the authorization code flow.**
+**Without this step, Idira Identity will return `invalid_client` errors during the authorization code flow.**
 
 ### Step 6: Assign Users/Roles
 
@@ -148,17 +148,17 @@ CYBERARK_CLIENT_SECRET=service-user-password
 
 1. **User connects** to the MCP server via an MCP client (claude.ai, Copilot Studio, etc.)
 2. **MCP client** calls DCR (`/register`) and receives the `client_id` (public client, no secret)
-3. **MCP client** redirects to CyberArk Identity for user authentication (authorization_code flow with PKCE)
+3. **MCP client** redirects to Idira Identity for user authentication (authorization_code flow with PKCE)
 4. **MCP server** receives the Bearer JWT token with each request
 5. **CyberArkTokenVerifier** validates the JWT signature against the JWKS endpoint (`/OAuth2/Keys/mcpprivilegecloud`, RS256)
 6. **execute_tool()** verifies user identity from the OIDC JWT, then routes API calls through the service account's platform token
-7. **Tools execute** under the service account's CyberArk permissions, with the authenticated user's identity logged for audit
+7. **Tools execute** under the service account's Idira permissions, with the authenticated user's identity logged for audit
 
 **Architecture note**: All API calls use a single shared service account platform token. The OIDC JWT is used solely for identity verification and audit logging -- it is not used for PCloud API authorization.
 
 ## JWT Validation
 
-The MCP server validates every incoming Bearer JWT against CyberArk Identity's JWKS endpoint. Understanding these checks helps diagnose authentication failures.
+The MCP server validates every incoming Bearer JWT against Idira Identity's JWKS endpoint. Understanding these checks helps diagnose authentication failures.
 
 **Signature**: RS256 only, verified against keys from `{tenant}/{app_name}/.well-known/openid-configuration` → `jwks_uri`. Keys are cached after first fetch.
 
@@ -176,7 +176,7 @@ The MCP server validates every incoming Bearer JWT against CyberArk Identity's J
 1. `CYBERARK_OAUTH_CLIENT_ID` — the Trust tab client ID (Part B, Step 3)
 2. Fallback: `CYBERARK_OIDC_APP_ID` (default: `mcpprivilegecloud`)
 
-CyberArk Identity sets `aud` to the `client_id` used in the authorization request. When DCR returns `CYBERARK_OAUTH_CLIENT_ID`, tokens will have that UUID as the audience.
+Idira Identity sets `aud` to the `client_id` used in the authorization request. When DCR returns `CYBERARK_OAUTH_CLIENT_ID`, tokens will have that UUID as the audience.
 
 **Debugging token issues**: Set `CYBERARK_LOG_LEVEL=DEBUG` to see the actual `iss`, `aud`, and `sub` claims from rejected tokens. You can also decode a token manually:
 
@@ -187,7 +187,7 @@ echo "<token>" | cut -d. -f2 | base64 -d 2>/dev/null | python3 -m json.tool
 
 ## OIDC App Configuration Reference
 
-The following details describe the expected configuration of the CyberArk Identity OIDC app created in Part B.
+The following details describe the expected configuration of the Idira Identity OIDC app created in Part B.
 
 | Setting | Value |
 |---------|-------|
@@ -226,11 +226,11 @@ For reference, the tenant-level discovery exposes:
 > **Important**: All authenticated users share the same service account's PCloud permissions. The OIDC JWT verifies *who* the user is, but API calls are executed using the service account's platform token. This means:
 >
 > - Any authenticated user can perform any operation the service account is authorized for
-> - Per-user permission enforcement is **not** supported — CyberArk PCloud does not accept OIDC tokens for API authorization
+> - Per-user permission enforcement is **not** supported — Idira PCloud does not accept OIDC tokens for API authorization
 > - The service account's roles and safe permissions define the ceiling for all users
 > - User identity is logged for audit purposes only
 >
-> **Recommendation**: Grant the service account the minimum PCloud permissions required, and restrict which users can authenticate by limiting the OIDC app's assigned users/roles in CyberArk Identity (Part B, Step 6).
+> **Recommendation**: Grant the service account the minimum PCloud permissions required, and restrict which users can authenticate by limiting the OIDC app's assigned users/roles in Idira Identity (Part B, Step 6).
 
 ## Security Considerations
 
@@ -239,7 +239,7 @@ For reference, the tenant-level discovery exposes:
 - The OIDC JWT establishes user identity for audit logging only
 - Service user credentials are stored server-side and never exposed to end users
 - DCR (`/register`) returns public client only (`token_endpoint_auth_method: "none"`) -- secrets are injected server-side by the `/token` proxy
-- Token verification uses RS256 signature validation via CyberArk Identity's public keys
+- Token verification uses RS256 signature validation via Idira Identity's public keys
 
 ## Troubleshooting
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,6 +1,6 @@
-# Development Guide - CyberArk Privilege Cloud MCP Server
+# Development Guide - Idira Privilege Cloud MCP Server
 
-This comprehensive guide provides everything developers need to contribute to the CyberArk Privilege Cloud MCP Server project.
+This comprehensive guide provides everything developers need to contribute to the Idira Privilege Cloud MCP Server project.
 
 ## Table of Contents
 
@@ -18,8 +18,8 @@ This comprehensive guide provides everything developers need to contribute to th
 
 - Python 3.11 or higher
 - Git
-- CyberArk Privilege Cloud tenant (for integration testing)
-- CyberArk Identity service account
+- Idira Privilege Cloud tenant (for integration testing)
+- Idira Identity service account
 
 ### Installation
 
@@ -37,7 +37,7 @@ This comprehensive guide provides everything developers need to contribute to th
    # Copy example configuration
    cp .env.example .env
    
-   # Edit .env with your CyberArk credentials
+   # Edit .env with your Idira credentials
    # Required variables:
    # CYBERARK_CLIENT_ID=your-service-account-username
    # CYBERARK_CLIENT_SECRET=your-service-account-password
@@ -195,7 +195,7 @@ async def create_account(
     user_name: Optional[str] = None
 ) -> Dict[str, Any]:
     """
-    Create a new privileged account in CyberArk Privilege Cloud.
+    Create a new privileged account in Idira Privilege Cloud.
     
     Args:
         platform_id: Platform ID for the account
@@ -293,7 +293,7 @@ async def test_async_operation(mock_server):
 ```python
 @pytest.fixture
 def mock_cyberark_api(mocker):
-    """Mock CyberArk API responses."""
+    """Mock Idira API responses."""
     mock_response = mocker.MagicMock()
     mock_response.json.return_value = {"value": []}
     mock_response.status_code = 200
@@ -365,7 +365,7 @@ async def test_api_error_handling(mock_server, mocker):
 ### Release Process
 
 1. **Automated Testing**: GitHub Actions runs full test suite
-2. **Manual Validation**: Test with MCP Inspector and real CyberArk environment
+2. **Manual Validation**: Test with MCP Inspector and real Idira environment
 3. **Documentation Updates**: Version numbers and changelog
 4. **Release Creation**: Git tag and release notes
 5. **CI/CD Verification**: All checks must pass
@@ -490,8 +490,8 @@ npx @modelcontextprotocol/inspector --cli -e CYBERARK_CLIENT_ID=your-client-id -
 #### Successful Connection Indicators
 - ✅ **Tool Count**: `tools/list` returns exactly 53 tools
 - ✅ **Resource Count**: `resources/list` returns empty array (correct - server uses tools, not resources)
-- ✅ **Authentication**: All tool calls require valid CyberArk credentials
-- ✅ **Response Format**: All tools return JSON with exact CyberArk API field names
+- ✅ **Authentication**: All tool calls require valid Idira credentials
+- ✅ **Response Format**: All tools return JSON with exact Idira API field names
 
 #### Tool Categories and Testing
 ```bash
@@ -542,12 +542,12 @@ npx @modelcontextprotocol/inspector --cli [env-vars] uvx --from git+https://gith
 
 **"401 Unauthorized"** 
 - **Cause**: Invalid service account credentials
-- **Solution**: Verify `CYBERARK_CLIENT_ID` and `CYBERARK_CLIENT_SECRET` in CyberArk Identity
+- **Solution**: Verify `CYBERARK_CLIENT_ID` and `CYBERARK_CLIENT_SECRET` in Idira Identity
 - **Debug**: Test credentials with direct API call
 
 **"403 Forbidden"**
 - **Cause**: Service account lacks required safe permissions
-- **Solution**: Grant appropriate safe access in CyberArk Privilege Cloud
+- **Solution**: Grant appropriate safe access in Idira Privilege Cloud
 - **Debug**: Check safe membership for the service account
 
 **"Empty response" or "No data returned"**
@@ -578,7 +578,7 @@ npx @modelcontextprotocol/inspector --cli [env-vars] uvx --from git+https://gith
 ```
 
 #### Step 4: Validate Response Structure
-- Verify responses contain exact CyberArk API field names (no transformations)
+- Verify responses contain exact Idira API field names (no transformations)
 - Check that platform tools return raw Policy INI values ("Yes"/"No", "12", etc.)
 - Confirm error responses provide helpful context
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing Guide
 
-Testing guide for LLM development of the CyberArk Privilege Cloud MCP Server. Focus on test structure, patterns, and validation strategies for AI-assisted development.
+Testing guide for LLM development of the Idira Privilege Cloud MCP Server. Focus on test structure, patterns, and validation strategies for AI-assisted development.
 
 ## Current Test Status ✅ **VERIFIED**
 
@@ -125,7 +125,7 @@ The test suite is organized into specialized test files with comprehensive cover
 ### Test Coverage Metrics
 - **Total Tests**: 260 tests across 14 test files
 - **Target Coverage**: Minimum 80% code coverage maintained across 53 tools
-- **Mock Strategy**: All external CyberArk API dependencies are mocked using official SDK patterns
+- **Mock Strategy**: All external Idira API dependencies are mocked using official SDK patterns
 - **Test Types**: Unit, integration, MCP tools tests across all 5 PCloud services
 - **Service Coverage**: Complete testing for ArkPCloudAccountsService, ArkPCloudSafesService, ArkPCloudPlatformsService, ArkPCloudApplicationsService, ArkSMService
 
@@ -138,7 +138,7 @@ The test suite is organized into specialized test files with comprehensive cover
 4. **Comprehensive Coverage**: Test both success and failure scenarios
 
 ### Mock Strategy
-- **External Dependencies**: All CyberArk API calls are mocked in unit tests
+- **External Dependencies**: All Idira API calls are mocked in unit tests
 - **Realistic Response Data**: Mock responses match real API behavior
 - **Error Simulation**: Mock various error conditions (401, 403, 429, 500)
 - **Network Conditions**: Simulate timeouts and connection failures
@@ -181,7 +181,7 @@ pytest -k account      # Account management tests
 
 ## MCP Inspector Testing
 
-For interactive testing of the MCP server against a live CyberArk environment, use the MCP Inspector:
+For interactive testing of the MCP server against a live Idira environment, use the MCP Inspector:
 
 ```bash
 # Run MCP Inspector


### PR DESCRIPTION
## What

Transitions docs to lead with the **Idira** brand (CyberArk's name after the Palo Alto Networks rebrand), preserving `CyberArk` for discoverability.

### Changed (prose only — no code)
- README: first mention → "Idira (formerly CyberArk)"; rest terse "Idira"
- `docs/*.md` (ARCHITECTURE, API_REFERENCE, DEVELOPMENT, TESTING, CYBERARK_IDENTITY_SETUP): brand-prose → "Idira"

### Intentionally NOT changed
- `CYBERARK_*` environment variable names
- `*.cyberark.cloud` / `docs.cyberark.com` URLs; `github.com/cyberark/ark-sdk-python`
- Code identifiers: `CyberArkMCPServer`, `CyberArkTokenVerifier`, `CyberArkAPIError`
- MCP server name `cyberark-privilege-cloud`, package `mcp_privilege_cloud`
- `CYBERARK_IDENTITY_SETUP.md` filename, CLAUDE.md, tests, repo name

Docs/markdown only — no code changed, so test suite is unaffected. Additive: CyberArk preserved in env vars, URLs, identifiers, slug, and GitHub metadata. Part of the org-wide CyberArk→Idira transition.